### PR TITLE
add overflow to status badge and bold bus num

### DIFF
--- a/style.css
+++ b/style.css
@@ -132,6 +132,7 @@ h3 {
     text-align: center;
     font-size: 48px;
     font-family: "urw-din-condensed", sans-serif;
+    font-weight: 700;
     font-style: normal;
     border-radius: 8px;
     background-color: #E28B41;
@@ -173,7 +174,7 @@ h3 {
     padding: 16px;
     font-weight: bold;
     font-size: 28px;
-    
+    overflow: auto;
 }
 
 .alert-item__status--ongoing {


### PR DESCRIPTION
Features:
- Use DIN (`font-weight: 700`) for bus line numbers in bus badges
- Add `overflow: auto;` to status badges to try to keep the parent div the width of the text.